### PR TITLE
Revert "refactor(export-map): Generate directory entries only"

### DIFF
--- a/packages/export-map/src/generate.ts
+++ b/packages/export-map/src/generate.ts
@@ -8,15 +8,8 @@ const CJS_EXT = ".js";
 const ESM_EXT = ".mjs";
 
 interface Export {
-  import: string;
   require: string;
-}
-
-function generateExport(path: string): Export {
-  return {
-    import: `./${path}${ESM_EXT}`,
-    require: `./${path}${CJS_EXT}`
-  };
+  import: string;
 }
 
 export interface GenerateArguments {
@@ -47,15 +40,16 @@ export async function generate(args: GenerateArguments): Promise<void> {
     if (ig.ignores(path)) continue;
 
     const base = trimSuffix(path, extname(path));
+    const exportPath =
+      base === "index" ? "." : `./${trimSuffix(base, "/index")}`;
+    const requirePath = `./${base}${CJS_EXT}`;
+    const importPath = `./${base}${ESM_EXT}`;
 
-    if (base === "index") {
-      exportMap["."] = generateExport(base);
-    } else if (base.endsWith("/index")) {
-      exportMap[`./${trimSuffix(base, "/index")}`] = generateExport(base);
-    }
+    exportMap[exportPath] = {
+      require: requirePath,
+      import: importPath
+    };
   }
-
-  exportMap["./*"] = generateExport("*");
 
   await writeJSON(args.export, exportMap, {
     spaces: 2


### PR DESCRIPTION
Reverts tommy351/kubernetes-models-ts#38

Because [Skypack](https://www.skypack.dev/) can't generate correct files when using wildcard exports.

Example: https://cdn.skypack.dev/-/kubernetes-models@v1.5.3-HGBDVPwLhlRY3gMJfmix/dist=es2020,mode=raw/_definitions/IoK8sApiCoreV1Pod.mjs

```js
import { Model } from "@kubernetes-models/base";
import { addSchema } from "../_schemas/IoK8sApiCoreV1Pod.mjs";
/**
 * Pod is a collection of containers that can run on a host. This resource is created by clients and scheduled onto hosts.
 */
export class IoK8sApiCoreV1Pod extends Model {
    constructor(data) {
        super({
            apiVersion: IoK8sApiCoreV1Pod.apiVersion,
            kind: IoK8sApiCoreV1Pod.kind,
            ...data
        });
    }
}
IoK8sApiCoreV1Pod.apiVersion = "v1";
IoK8sApiCoreV1Pod.kind = "Pod";
Model.setSchema(IoK8sApiCoreV1Pod, "io.k8s.api.core.v1.Pod", addSchema);
export { IoK8sApiCoreV1Pod as Pod };
```