### PR TITLE
Include /src files in published packages (base, validate)

### DIFF
--- a/core/base/package.json
+++ b/core/base/package.json
@@ -29,7 +29,8 @@
     "access": "public"
   },
   "files": [
-    "/dist/"
+    "/dist/",
+    "/src/"
   ],
   "engines": {
     "node": ">=14"

--- a/core/validate/package.json
+++ b/core/validate/package.json
@@ -30,7 +30,8 @@
     "validate"
   ],
   "files": [
-    "/dist/"
+    "/dist/",
+    "/src/"
   ],
   "engines": {
     "node": ">=14"


### PR DESCRIPTION
While working with this library I noticed that for the  `base` and `validate` packages the webpack was throwing warnings related to the source maps referencing missing files:

```
WARNING in ../../node_modules/.pnpm/@kubernetes-models+validate@3.0.0/node_modules/@kubernetes-models/validate/dist/index.js
Module Warning (from ../../node_modules/.pnpm/source-map-loader@2.0.2_webpack@5.70.0/node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/Users/thiagolugli/ibm/kie-tools/node_modules/.pnpm/@kubernetes-models+validate@3.0.0/node_modules/@kubernetes-models/validate/src/index.ts' file: Error: ENOENT: no such file or directory, open '/Users/thiagolugli/ibm/kie-tools/node_modules/.pnpm/@kubernetes-models+validate@3.0.0/node_modules/@kubernetes-models/validate/src/index.ts'
```
and
```
WARNING in ../../node_modules/.pnpm/@kubernetes-models+base@4.0.0/node_modules/@kubernetes-models/base/dist/model.js
Module Warning (from ../../node_modules/.pnpm/source-map-loader@2.0.2_webpack@5.70.0/node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/Users/thiagolugli/ibm/kie-tools/node_modules/.pnpm/@kubernetes-models+base@4.0.0/node_modules/@kubernetes-models/base/src/model.ts' file: Error: ENOENT: no such file or directory, open '/Users/thiagolugli/ibm/kie-tools/node_modules/.pnpm/@kubernetes-models+base@4.0.0/node_modules/@kubernetes-models/base/src/model.ts'
```

My suspicion is that since the `/src` directory is not published with those packages the `source-map-loader` can't reference them.

The solution proposed here is to publish the `/src` directory.