### PR TITLE
Apply `oneOf`, `anyOf`, `allOf` rules after `type` and support draft2019 formats

### DIFF
--- a/.changeset/red-insects-sneeze.md
+++ b/.changeset/red-insects-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@kubernetes-models/validate": minor
+---
+
+Add support for more formats: `iri`, `iri-reference`, `idn-email`, `idn-hostname`, `duration`.

--- a/.changeset/warm-fireants-burn.md
+++ b/.changeset/warm-fireants-burn.md
@@ -1,0 +1,29 @@
+---
+"@kubernetes-models/generate": minor
+---
+
+Apply `oneOf`, `allOf`, `anyOf` after `type` is applied to better support [factoring schemas](https://json-schema.org/understanding-json-schema/reference/combining.html#factoring-schemas), which is used in Cilium `CiliumClusterwideNetworkPolicy` CRD.
+
+```json
+{
+  "spec": {
+    "oneOf": [
+      {
+        "properties": {
+          "endpointSelector": {}
+        },
+        "required": ["endpointSelector"]
+      },
+      {
+        "properties": {
+          "nodeSelector": {}
+        },
+        "required": ["nodeSelector"]
+      }
+    ],
+    "properties": {
+      // ...
+    }
+  }
+}
+```

--- a/core/validate/package.json
+++ b/core/validate/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "ajv": "^8.11.0",
     "ajv-formats": "^2.1.1",
+    "ajv-formats-draft2019": "^1.6.1",
     "tslib": "^2.4.0"
   },
   "devDependencies": {

--- a/core/validate/src/__tests__/ajv.ts
+++ b/core/validate/src/__tests__/ajv.ts
@@ -168,3 +168,15 @@ describe("format: quantity", () => {
     expect(result).toEqual(expected);
   });
 });
+
+describe("format: string", () => {
+  it.each([
+    ["foo", true],
+    [1, false],
+    [true, false]
+  ])("%s -> %p", (input, expected) => {
+    const result = ajv.validate({ type: "string", format: "string" }, input);
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/core/validate/src/ajv.ts
+++ b/core/validate/src/ajv.ts
@@ -1,5 +1,6 @@
 import Ajv, { AnySchema } from "ajv";
 import addFormats from "ajv-formats";
+import addFormatsDraft2019 from "ajv-formats-draft2019";
 
 // From: https://github.com/miguelmota/is-base64/blob/0702e189090921a2f11b4342f27906ff8c43d7ec/is-base64.js#L15
 const rBase64 =
@@ -26,6 +27,7 @@ export const ajv = new Ajv({
 });
 
 addFormats(ajv);
+addFormatsDraft2019(ajv);
 
 export function register(id: string, schema: AnySchema): void {
   if (!ajv.getSchema(id)) {

--- a/core/validate/tsconfig.json
+++ b/core/validate/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": ["src"]
+  "include": ["src", "types.d.ts"]
 }

--- a/core/validate/types.d.ts
+++ b/core/validate/types.d.ts
@@ -1,0 +1,5 @@
+declare module "ajv-formats-draft2019" {
+  import Ajv from "ajv";
+
+  export default function (ajv: Ajv): Ajv;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       ajv-formats:
         specifier: ^2.1.1
         version: 2.1.1(ajv@8.11.0)
+      ajv-formats-draft2019:
+        specifier: ^1.6.1
+        version: 1.6.1(ajv@8.11.0)
       tslib:
         specifier: ^2.4.0
         version: 2.4.0
@@ -2207,6 +2210,18 @@ packages:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
+  /ajv-formats-draft2019@1.6.1(ajv@8.11.0):
+    resolution: {integrity: sha512-JQPvavpkWDvIsBp2Z33UkYCtXCSpW4HD3tAZ+oL4iEFOk9obQZffx0yANwECt6vzr6ET+7HN5czRyqXbnq/u0Q==}
+    peerDependencies:
+      ajv: '*'
+    dependencies:
+      ajv: 8.11.0
+      punycode: 2.1.1
+      schemes: 1.4.0
+      smtp-address-parser: 1.0.10
+      uri-js: 4.4.1
+    dev: false
+
   /ajv-formats@2.1.1(ajv@8.11.0):
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
@@ -2550,6 +2565,10 @@ packages:
       delayed-stream: 1.0.0
     dev: true
 
+  /commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+    dev: false
+
   /commander@9.3.0:
     resolution: {integrity: sha512-hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw==}
     engines: {node: ^12.20.0 || >=14}
@@ -2723,6 +2742,10 @@ packages:
     dependencies:
       path-type: 4.0.0
     dev: true
+
+  /discontinuous-range@1.0.0:
+    resolution: {integrity: sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==}
+    dev: false
 
   /doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
@@ -3085,6 +3108,10 @@ packages:
   /expect-more@1.2.0:
     resolution: {integrity: sha512-AVnjc5oh2jgiJjOrjbiKxbwLlNA/zsl2044Nbd09H4+2KwThtSLYKhdOusLYOrcToFAa2uBOWR1ExCN4kOWgbQ==}
     dev: true
+
+  /extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+    dev: false
 
   /extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
@@ -4103,6 +4130,10 @@ packages:
       ufo: 1.1.1
     dev: true
 
+  /moo@0.5.2:
+    resolution: {integrity: sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==}
+    dev: false
+
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
 
@@ -4118,6 +4149,16 @@ packages:
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
+
+  /nearley@2.20.1:
+    resolution: {integrity: sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==}
+    hasBin: true
+    dependencies:
+      commander: 2.20.3
+      moo: 0.5.2
+      railroad-diagrams: 1.0.0
+      randexp: 0.4.6
+    dev: false
 
   /negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
@@ -4507,6 +4548,18 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /railroad-diagrams@1.0.0:
+    resolution: {integrity: sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==}
+    dev: false
+
+  /randexp@0.4.6:
+    resolution: {integrity: sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==}
+    engines: {node: '>=0.12'}
+    dependencies:
+      discontinuous-range: 1.0.0
+      ret: 0.1.15
+    dev: false
+
   /react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
     dev: true
@@ -4647,6 +4700,11 @@ packages:
       signal-exit: 3.0.7
     dev: true
 
+  /ret@0.1.15:
+    resolution: {integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==}
+    engines: {node: '>=0.12'}
+    dev: false
+
   /retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
@@ -4701,6 +4759,12 @@ packages:
 
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  /schemes@1.4.0:
+    resolution: {integrity: sha512-ImFy9FbCsQlVgnE3TCWmLPCFnVzx0lHL/l+umHplDqAKd0dzFpnS6lFZIpagBlYhKwzVmlV36ec0Y1XTu8JBAQ==}
+    dependencies:
+      extend: 3.0.2
+    dev: false
 
   /semver@5.7.1:
     resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
@@ -4814,6 +4878,13 @@ packages:
       wcwidth: 1.0.1
       yargs: 15.4.1
     dev: true
+
+  /smtp-address-parser@1.0.10:
+    resolution: {integrity: sha512-Osg9LmvGeAG/hyao4mldbflLOkkr3a+h4m1lwKCK5U8M6ZAr7tdXEz/+/vr752TSGE4MNUlUl9cIK2cB8cgzXg==}
+    engines: {node: '>=0.10'}
+    dependencies:
+      nearley: 2.20.1
+    dev: false
 
   /socks-proxy-agent@7.0.0:
     resolution: {integrity: sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==}

--- a/third-party/cilium/__tests__/class.ts
+++ b/third-party/cilium/__tests__/class.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { CiliumLocalRedirectPolicy } from "../gen/cilium.io/v2/CiliumLocalRedirectPolicy";
+import { CiliumClusterwideNetworkPolicy } from "../gen/cilium.io/v2/CiliumClusterwideNetworkPolicy";
 
 describe("CiliumLocalRedirectPolicy", () => {
   let lrp: CiliumLocalRedirectPolicy;
@@ -76,6 +77,90 @@ describe("CiliumLocalRedirectPolicy", () => {
             }
           ]
         }
+      }
+    });
+  });
+});
+
+describe("CiliumClusterwideNetworkPolicy", () => {
+  let policy: CiliumClusterwideNetworkPolicy;
+
+  beforeEach(() => {
+    policy = new CiliumClusterwideNetworkPolicy({
+      metadata: {
+        name: "example"
+      },
+      spec: {
+        endpointSelector: { matchLabels: { app: "service" } },
+        ingress: [
+          {
+            fromEndpoints: [{ matchLabels: { env: "prod" } }]
+          },
+          {
+            toPorts: [
+              {
+                ports: [{ port: "80", protocol: "TCP" }],
+                rules: {
+                  http: [
+                    {
+                      method: "GET",
+                      path: "/public"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    });
+  });
+
+  it("should set apiVersion", () => {
+    expect(policy).toHaveProperty("apiVersion", "cilium.io/v2");
+  });
+
+  it("should set kind", () => {
+    expect(policy).toHaveProperty("kind", "CiliumClusterwideNetworkPolicy");
+  });
+
+  it("should set metadata", () => {
+    expect(policy.metadata).toEqual({ name: "example" });
+  });
+
+  it("should set sepc", () => {
+    expect(policy).toHaveProperty("spec");
+  });
+
+  it("toJSON", () => {
+    expect(policy.toJSON()).toEqual({
+      apiVersion: "cilium.io/v2",
+      kind: "CiliumClusterwideNetworkPolicy",
+      metadata: {
+        name: "example"
+      },
+      spec: {
+        endpointSelector: { matchLabels: { app: "service" } },
+        ingress: [
+          {
+            fromEndpoints: [{ matchLabels: { env: "prod" } }]
+          },
+          {
+            toPorts: [
+              {
+                ports: [{ port: "80", protocol: "TCP" }],
+                rules: {
+                  http: [
+                    {
+                      method: "GET",
+                      path: "/public"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
       }
     });
   });

--- a/third-party/cilium/__tests__/validate.ts
+++ b/third-party/cilium/__tests__/validate.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { CiliumLocalRedirectPolicy } from "../gen/cilium.io/v2/CiliumLocalRedirectPolicy";
+import { CiliumClusterwideNetworkPolicy } from "../gen/cilium.io/v2/CiliumClusterwideNetworkPolicy";
 
-describe("validate", () => {
+describe("CiliumLocalRedirectPolicy", () => {
   describe("when validation passed", () => {
     it("should pass", () => {
       const lrp = new CiliumLocalRedirectPolicy({
@@ -53,6 +54,64 @@ describe("validate", () => {
 
       expect(() => lrp.validate()).toThrow(
         "data/spec/redirectFrontend must have required property 'addressMatcher', data/spec/redirectFrontend must have required property 'serviceMatcher', data/spec/redirectFrontend must match exactly one schema in oneOf"
+      );
+    });
+  });
+});
+
+describe("CiliumClusterwideNetworkPolicy", () => {
+  describe("when endpointSelector is defined", () => {
+    it("should pass", () => {
+      const policy = new CiliumClusterwideNetworkPolicy({
+        metadata: { name: "test" },
+        spec: {
+          endpointSelector: {}
+        }
+      });
+
+      expect(() => policy.validate()).not.toThrow();
+    });
+  });
+
+  describe("when nodeSelector is defined", () => {
+    it("should pass", () => {
+      const policy = new CiliumClusterwideNetworkPolicy({
+        metadata: { name: "test" },
+        spec: {
+          nodeSelector: {}
+        }
+      });
+
+      expect(() => policy.validate()).not.toThrow();
+    });
+  });
+
+  describe("when both endpointSelector and nodeSelector are defined", () => {
+    it("should throw an error", () => {
+      const policy = new CiliumClusterwideNetworkPolicy({
+        metadata: { name: "test" },
+        spec: {
+          endpointSelector: {},
+          nodeSelector: {}
+        }
+      });
+
+      expect(() => policy.validate()).toThrow(
+        "data/spec must match exactly one schema in oneOf"
+      );
+    });
+  });
+
+  describe("when neither endpointSelector nor nodeSelector are defined", () => {
+    it("should throw an error", () => {
+      const policy = new CiliumClusterwideNetworkPolicy({
+        metadata: { name: "test" },
+        // @ts-expect-error
+        spec: {}
+      });
+
+      expect(() => policy.validate()).toThrow(
+        "data/spec must have required property 'endpointSelector', data/spec must have required property 'nodeSelector', data/spec must match exactly one schema in oneOf"
       );
     });
   });


### PR DESCRIPTION
Fix #124 