### PR TITLE
updated to  istio 1.18.0and ajv 8.12

### DIFF
--- a/core/validate/package.json
+++ b/core/validate/package.json
@@ -36,7 +36,7 @@
     "node": ">=14"
   },
   "dependencies": {
-    "ajv": "^8.11.0",
+    "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
     "ajv-formats-draft2019": "^1.6.1",
     "tslib": "^2.4.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
@@ -105,14 +109,14 @@ importers:
   core/validate:
     dependencies:
       ajv:
-        specifier: ^8.11.0
-        version: 8.11.0
+        specifier: ^8.12.0
+        version: 8.12.0
       ajv-formats:
         specifier: ^2.1.1
-        version: 2.1.1(ajv@8.11.0)
+        version: 2.1.1(ajv@8.12.0)
       ajv-formats-draft2019:
         specifier: ^1.6.1
-        version: 1.6.1(ajv@8.11.0)
+        version: 1.6.1(ajv@8.12.0)
       tslib:
         specifier: ^2.4.0
         version: 2.4.0
@@ -1141,8 +1145,8 @@ importers:
         specifier: workspace:^
         version: link:../string-util
       ajv:
-        specifier: ^8.11.0
-        version: 8.11.0
+        specifier: ^8.12.0
+        version: 8.12.0
       fs-extra:
         specifier: ^10.1.0
         version: 10.1.0
@@ -2210,19 +2214,19 @@ packages:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  /ajv-formats-draft2019@1.6.1(ajv@8.11.0):
+  /ajv-formats-draft2019@1.6.1(ajv@8.12.0):
     resolution: {integrity: sha512-JQPvavpkWDvIsBp2Z33UkYCtXCSpW4HD3tAZ+oL4iEFOk9obQZffx0yANwECt6vzr6ET+7HN5czRyqXbnq/u0Q==}
     peerDependencies:
       ajv: '*'
     dependencies:
-      ajv: 8.11.0
+      ajv: 8.12.0
       punycode: 2.1.1
       schemes: 1.4.0
       smtp-address-parser: 1.0.10
       uri-js: 4.4.1
     dev: false
 
-  /ajv-formats@2.1.1(ajv@8.11.0):
+  /ajv-formats@2.1.1(ajv@8.12.0):
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
       ajv: ^8.0.0
@@ -2230,7 +2234,7 @@ packages:
       ajv:
         optional: true
     dependencies:
-      ajv: 8.11.0
+      ajv: 8.12.0
     dev: false
 
   /ajv@6.12.6:
@@ -2242,8 +2246,8 @@ packages:
       uri-js: 4.4.1
     dev: true
 
-  /ajv@8.11.0:
-    resolution: {integrity: sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==}
+  /ajv@8.12.0:
+    resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
     dependencies:
       fast-deep-equal: 3.1.3
       json-schema-traverse: 1.0.0

--- a/third-party/istio/package.json
+++ b/third-party/istio/package.json
@@ -42,8 +42,8 @@
   },
   "crd-generate": {
     "input": [
-      "https://raw.githubusercontent.com/istio/istio/1.16.1/manifests/charts/base/crds/crd-all.gen.yaml",
-      "https://raw.githubusercontent.com/istio/istio/1.16.1/manifests/charts/base/crds/crd-operator.yaml"
+      "https://raw.githubusercontent.com/istio/istio/1.18.0/manifests/charts/base/crds/crd-all.gen.yaml",
+      "https://raw.githubusercontent.com/istio/istio/1.18.0/manifests/charts/base/crds/crd-operator.yaml"
     ],
     "output": "./gen"
   }

--- a/utils/generate/package.json
+++ b/utils/generate/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@kubernetes-models/string-util": "workspace:^",
-    "ajv": "^8.11.0",
+    "ajv": "^8.12.0",
     "fs-extra": "^10.1.0",
     "indent-string": "^4.0.0",
     "lodash": "^4.17.21",


### PR DESCRIPTION
ajv 8.11.2 has a fix for this error:

"default" is not exported by "node_modules/ajv/dist/ajv.js", imported by "node_modules/@kubernetes-models/validate/dist/ajv.mjs".

istio 1.18.0 was just released and would be nice to have all the new changes in it, though not sure they're helpful. 

This is a cool package, and thank you :) 