### PR TITLE
feat: Add new Pipelines-as-Code models

### DIFF
--- a/.changeset/fuzzy-lobsters-accept.md
+++ b/.changeset/fuzzy-lobsters-accept.md
@@ -1,0 +1,5 @@
+---
+"@kubernetes-models/pipelines-as-code": minor
+---
+
+Initial [Pipelines-as-Code](https://pipelinesascode.com/) models based on the Pipeline-as-Code release v0.21.1.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ See [examples](examples) folder for more examples.
 - [@kubernetes-models/keda](third-party/keda) - [KEDA](https://github.com/kedacore/keda) models.
 - [@kubernetes-models/knative](third-party/knative) - [Knative](https://knative.dev/) models.
 - [@kubernetes-models/kubedb](third-party/kubedb) - [KubeDB](https://kubedb.com/) models.
+- [@kubernetes-models/pipelines-as-code](third-party/pipelines-as-code) - [Pipelines-as-Code](https://pipelinesascode.com/) models.
 - [@kubernetes-models/postgres-operator](third-party/postgres-operator) - PostgreSQL operator models.
 - [@kubernetes-models/prometheus-operator](third-party/prometheus-operator) - [Prometheus operator](https://github.com/prometheus-operator/prometheus-operator/) models.
 - [@kubernetes-models/rabbitmq-cluster-operator](third-party/rabbitmq-cluster-operator/) - [RabbitMQ cluster operator](https://github.com/rabbitmq/cluster-operator) models.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -786,6 +786,32 @@ importers:
         version: 0.29.8
     publishDirectory: dist
 
+  third-party/pipelines-as-code:
+    dependencies:
+      '@kubernetes-models/apimachinery':
+        specifier: workspace:^
+        version: link:../../first-party/apimachinery/dist
+      '@kubernetes-models/base':
+        specifier: workspace:^
+        version: link:../../core/base
+      '@kubernetes-models/validate':
+        specifier: workspace:^
+        version: link:../../core/validate
+      tslib:
+        specifier: ^2.4.0
+        version: 2.4.0
+    devDependencies:
+      '@kubernetes-models/crd-generate':
+        specifier: workspace:^
+        version: link:../../utils/crd-generate
+      '@kubernetes-models/publish-scripts':
+        specifier: workspace:^
+        version: link:../../internal/publish-scripts
+      vitest:
+        specifier: ^0.29.8
+        version: 0.29.8
+    publishDirectory: dist
+
   third-party/postgres-operator:
     dependencies:
       '@kubernetes-models/apimachinery':

--- a/third-party/pipelines-as-code/README.md
+++ b/third-party/pipelines-as-code/README.md
@@ -1,0 +1,44 @@
+# @kubernetes-models/pipelines-as-code
+
+[Pipelines-as-Code](https://pipelinesascode.com/) models.
+
+## Installation
+
+Install with npm.
+
+```sh
+npm install @kubernetes-models/pipelines-as-code
+```
+
+## Usage
+
+```js
+import { Repository } from "@kubernetes-models/pipelines-as-code/pipelinesascode.tekton.dev/v1alpha1/Repository";
+
+// Create a new Application
+const repository = new Repository({
+  metadata: {
+    name: "pac-repo"
+  },
+  spec: {
+    url: "https://github.com/linda/project",
+    git_provider: {
+      secret: {
+        name: 'my-secret',
+        key: 'repo-secret',
+      },
+      webhook_secret: {
+        name: 'my-secret',
+        key: 'webhook-secret',
+      },
+    },
+  },
+});
+
+// Validate against JSON schema
+app.validate();
+```
+
+## License
+
+MIT

--- a/third-party/pipelines-as-code/__tests__/class.ts
+++ b/third-party/pipelines-as-code/__tests__/class.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Repository } from "../gen/pipelinesascode.tekton.dev/v1alpha1/Repository";
+
+describe("Repository", () => {
+  let repository: Repository;
+
+  beforeEach(() => {
+    repository = new Repository({
+      metadata: {
+        name: "test-repository"
+      },
+      spec: {
+        url: "https://github.com/linda/project",
+      }
+    });
+  });
+
+  it("should set apiVersion", () => {
+    expect(repository).toHaveProperty("apiVersion", "pipelinesascode.tekton.dev/v1alpha1");
+  });
+
+  it("should set kind", () => {
+    expect(repository).toHaveProperty("kind", "Repository");
+  });
+
+  it("validate", () => {
+    expect(() => repository.validate()).not.toThrow();
+  });
+
+  it("toJSON", () => {
+    expect(repository.toJSON()).toEqual({
+      apiVersion: "pipelinesascode.tekton.dev/v1alpha1",
+      kind: "Repository",
+      metadata: {
+        name: "test-repository"
+      },
+      spec: {
+        url: "https://github.com/linda/project",
+      },
+    });
+  });
+
+  it("should support type", () => {
+    if (repository.spec) {
+      repository.spec.type = 'github';
+    }
+    expect(() => repository.validate()).not.toThrow();
+  });
+
+  it("should support concurrency_limit", () => {
+    if (repository.spec) {
+      repository.spec.concurrency_limit = 3;
+    }
+    expect(() => repository.validate()).not.toThrow();
+  });
+
+  it("should support different parameters", () => {
+    if (repository.spec) {
+      repository.spec.params = [
+        { name: 'company', value: 'My Beautiful Company' },
+        { name: 'company', secret_ref: { name: 'my-secret', key: 'companyname' } },
+        { name: 'company', value: 'My Beautiful Company', filter: 'pac.event_type == "pull_request"' },
+      ];
+    }
+    expect(() => repository.validate()).not.toThrow();
+  });
+
+  it("should support settings", () => {
+    if (repository.spec) {
+      repository.spec.settings = {
+        github_app_token_scope_repos: [
+          'owner/project',
+          'owner1/project1',
+        ],
+      };
+    }
+    expect(() => repository.validate()).not.toThrow();
+  });
+
+  it("should support git_providers", () => {
+    if (repository.spec) {
+      repository.spec.git_provider = {
+        user: 'bot',
+        secret: {
+          name: 'my-secret',
+          key: 'repo-secret',
+        },
+        webhook_secret: {
+          name: 'my-secret',
+          key: 'webhook-secret',
+        }
+      };
+    }
+    expect(() => repository.validate()).not.toThrow();
+  });
+});

--- a/third-party/pipelines-as-code/package.json
+++ b/third-party/pipelines-as-code/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@kubernetes-models/pipelines-as-code",
+  "version": "0.0.0",
+  "description": "Pipelines-as-Code models",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tommy351/kubernetes-models-ts.git"
+  },
+  "homepage": "https://github.com/tommy351/kubernetes-models-ts/tree/master/third-party/pipelines-as-code",
+  "author": "Christoph Jerolimov <jerolimov@redhat.com>",
+  "license": "MIT",
+  "main": "index.cjs",
+  "module": "index.mjs",
+  "types": "index.d.ts",
+  "sideEffects": false,
+  "scripts": {
+    "build": "crd-generate && publish-scripts build",
+    "prepack": "publish-scripts prepack"
+  },
+  "publishConfig": {
+    "access": "public",
+    "directory": "dist",
+    "linkDirectory": true
+  },
+  "keywords": [
+    "kubernetes",
+    "kubernetes-models",
+    "tekton",
+    "tektoncd",
+    "pipelines-as-code"
+  ],
+  "engines": {
+    "node": ">=14"
+  },
+  "dependencies": {
+    "@kubernetes-models/apimachinery": "workspace:^",
+    "@kubernetes-models/base": "workspace:^",
+    "@kubernetes-models/validate": "workspace:^",
+    "tslib": "^2.4.0"
+  },
+  "devDependencies": {
+    "@kubernetes-models/crd-generate": "workspace:^",
+    "@kubernetes-models/publish-scripts": "workspace:^",
+    "vitest": "^0.29.8"
+  },
+  "crd-generate": {
+    "input": [
+      "https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/v0.21.1/config/300-repositories.yaml"
+    ],
+    "output": "./gen"
+  }
+}

--- a/third-party/pipelines-as-code/tsconfig.json
+++ b/third-party/pipelines-as-code/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "sourceMap": false
+  },
+  "include": ["gen"]
+}


### PR DESCRIPTION
Hi @tommy351, I really appreciate your work here.:+1: 

This PR adds CRD-generated models for [Pipelines-as-Code](https://pipelinesascode.com/). See the committed README.md and CHANGELOG.md.

Pipelines-as-code is a [Tekton](https://tekton.dev/)-based solution, or extension for Tekton, to commit the Pipeline definitions similar to GitHub Actions into a Git Repository.

FYI: I'm also working on a package for Tekton, but their CRD definition isn't complete. I'm looking into that issue at the moment.

Let me know if you need more info or if anything is missing.