### PR TITLE
Add interoperability with kubernetes-client/javascript

### DIFF
--- a/core/base/package.json
+++ b/core/base/package.json
@@ -37,7 +37,8 @@
   "dependencies": {
     "@kubernetes-models/validate": "workspace:^",
     "is-plain-object": "^5.0.0",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.0",
+    "@kubernetes/client-node": "^0.20.0"
   },
   "devDependencies": {
     "tsc-multi": "^0.6.1",

--- a/core/base/src/index.ts
+++ b/core/base/src/index.ts
@@ -1,2 +1,2 @@
-export { Model, ModelData, ModelConstructor, setSchema } from "./model";
+export { Model, ModelData, ModelConstructor, KubernetesObjectWithOptionalSpec, KubernetesObject, KubernetesObjectWithSpec, V1ObjectMeta, setSchema } from "./model";
 export { TypeMeta, TypeMetaGuard, createTypeMetaGuard } from "./meta";

--- a/core/base/src/model.ts
+++ b/core/base/src/model.ts
@@ -1,6 +1,7 @@
 import { isPlainObject } from "is-plain-object";
 import { validate } from "@kubernetes-models/validate";
 import { TypeMeta } from "./meta";
+import { KubernetesObject, KubernetesObjectWithSpec, V1ObjectMeta } from '@kubernetes/client-node';
 
 const SCHEMA_ID = Symbol("SCHEMA_ID");
 const ADD_SCHEMA = Symbol("ADD_SCHEMA");
@@ -26,6 +27,14 @@ function filterUndefinedValues(data: unknown): unknown {
   }
 
   return data;
+}
+
+export { KubernetesObjectWithSpec };
+export { KubernetesObject };
+export { V1ObjectMeta };
+
+export interface KubernetesObjectWithOptionalSpec extends KubernetesObject {
+  spec?: object;
 }
 
 export type ModelData<T> = T extends TypeMeta ? Omit<T, keyof TypeMeta> : T;


### PR DESCRIPTION
Adding interoperability with [kubernetes-client/javascript](https://github.com/kubernetes-client/javascript) will allow one to use [the objects api](https://github.com/kubernetes-client/javascript/blob/master/src/object.ts) to fetch, delete, patch and so on using the types generated from this repository.

kubernetes-client/javascript has a terrible experience for generated typed custom crds while this repository has a great one and even validation. All of which will make it a great developer experience to generate your types and use the api.