### PR TITLE
feat(third-party): bump `gateway-api` to v1.0.0

### DIFF
--- a/.changeset/tiny-berries-sneeze.md
+++ b/.changeset/tiny-berries-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@kubernetes-models/gateway-api": minor
+---
+
+bump to v1.0.0

--- a/third-party/gateway-api/README.md
+++ b/third-party/gateway-api/README.md
@@ -13,7 +13,7 @@ npm install @kubernetes-models/gateway-api
 ## Usage
 
 ```js
-import { HTTPRoute } from "@kubernetes-models/gateway-api/gateway.networking.k8s.io/v1beta1/HTTPRoute";
+import { HTTPRoute } from "@kubernetes-models/gateway-api/gateway.networking.k8s.io/v1/HTTPRoute";
 
 // Create a new HTTPRoute
 const route = new HTTPRoute({

--- a/third-party/gateway-api/__tests__/class.ts
+++ b/third-party/gateway-api/__tests__/class.ts
@@ -1,11 +1,75 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { HTTPRoute } from "../gen/gateway.networking.k8s.io/v1beta1/HTTPRoute";
+import { HTTPRoute } from "../gen/gateway.networking.k8s.io/v1/HTTPRoute";
+import { HTTPRoute as HTTPRouteV1Beta1 } from "../gen/gateway.networking.k8s.io/v1beta1/HTTPRoute";
 
 describe("HTTPRoute", () => {
   let route: HTTPRoute;
 
   beforeEach(() => {
     route = new HTTPRoute({
+      metadata: {
+        name: "http-route"
+      },
+      spec: {
+        parentRefs: [
+          {
+            kind: "Gateway",
+            name: "foo-gateway"
+          }
+        ],
+        rules: [
+          {
+            backendRefs: [{ name: "foo-svc", port: 8080 }]
+          }
+        ]
+      }
+    });
+  });
+
+  it("should set apiVersion", () => {
+    expect(route).toHaveProperty(
+      "apiVersion",
+      "gateway.networking.k8s.io/v1"
+    );
+  });
+
+  it("should set kind", () => {
+    expect(route).toHaveProperty("kind", "HTTPRoute");
+  });
+
+  it("validate", () => {
+    expect(() => route.validate()).not.toThrow();
+  });
+
+  it("toJSON", () => {
+    expect(route.toJSON()).toEqual({
+      apiVersion: "gateway.networking.k8s.io/v1",
+      kind: "HTTPRoute",
+      metadata: {
+        name: "http-route"
+      },
+      spec: {
+        parentRefs: [
+          {
+            kind: "Gateway",
+            name: "foo-gateway"
+          }
+        ],
+        rules: [
+          {
+            backendRefs: [{ name: "foo-svc", port: 8080 }]
+          }
+        ]
+      }
+    });
+  });
+});
+
+describe("HTTPRoute v1beta1", () => {
+  let route: HTTPRouteV1Beta1;
+
+  beforeEach(() => {
+    route = new HTTPRouteV1Beta1({
       metadata: {
         name: "http-route"
       },

--- a/third-party/gateway-api/package.json
+++ b/third-party/gateway-api/package.json
@@ -43,7 +43,8 @@
   },
   "crd-generate": {
     "input": [
-      "https://github.com/kubernetes-sigs/gateway-api/releases/download/v0.6.2/standard-install.yaml"
+      "https://github.com/kubernetes-sigs/gateway-api/releases/download/v0.6.2/standard-install.yaml",
+      "https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0/standard-install.yaml"
     ],
     "output": "./gen"
   }


### PR DESCRIPTION
## Desc
Bump `gateway-api` to [v1.0.0](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.0.0).