### PR TITLE
feat: Add experimental to gateway-api for many other CRDs

### DIFF
--- a/third-party/gateway-api/package.json
+++ b/third-party/gateway-api/package.json
@@ -44,7 +44,8 @@
   "crd-generate": {
     "input": [
       "https://github.com/kubernetes-sigs/gateway-api/releases/download/v0.6.2/standard-install.yaml",
-      "https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0/standard-install.yaml"
+      "https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0/standard-install.yaml",
+      "https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0/experimental-install.yaml"
     ],
     "output": "./gen"
   }


### PR DESCRIPTION
Hello,

I'm building an GUI like traeffik dashboard for gateway API and i'm looking for more experimental CRDs.
Is it possible to add them ?

Regards