### PR TITLE
chore(third-party/envoy-gateway): support eg v0.5.0 also

### DIFF
--- a/.changeset/wicked-spies-count.md
+++ b/.changeset/wicked-spies-count.md
@@ -1,0 +1,5 @@
+---
+"@kubernetes-models/envoy-gateway": patch
+---
+
+Support Envoy Gateway v0.5.0 also

--- a/third-party/envoy-gateway/__tests__/class.ts
+++ b/third-party/envoy-gateway/__tests__/class.ts
@@ -6,6 +6,7 @@ import {
   EnvoyProxy,
   SecurityPolicy
 } from "../gen/gateway.envoyproxy.io/v1alpha1";
+import * as v05 from "../gen/config.gateway.envoyproxy.io/v1alpha1";
 
 describe("BackendTrafficPolicy", () => {
   let policy: BackendTrafficPolicy;
@@ -336,6 +337,97 @@ describe("SecurityPolicy", () => {
           namespace: "envoy-gateway"
         }
       }
+    });
+  });
+});
+
+describe("v0.5.0", () => {
+  describe("EnvoyProxy", () => {
+    let proxy: v05.EnvoyProxy;
+
+    beforeEach(() => {
+      proxy = new v05.EnvoyProxy({
+        metadata: {
+          namespace: "envoy-gateway-system",
+          name: "test"
+        },
+        spec: {
+          telemetry: {
+            accessLog: {
+              settings: [
+                {
+                  format: {
+                    type: "JSON",
+                    json: {
+                      protocol: "%PROTOCOL%",
+                      duration: "%DURATION%"
+                    }
+                  },
+                  sinks: [
+                    {
+                      type: "File",
+                      file: {
+                        path: "/dev/stdout"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      });
+    });
+
+    it("should set apiVersion", () => {
+      expect(proxy).toHaveProperty(
+        "apiVersion",
+        "config.gateway.envoyproxy.io/v1alpha1"
+      );
+    });
+
+    it("should set kind", () => {
+      expect(proxy).toHaveProperty("kind", "EnvoyProxy");
+    });
+
+    it("validate", () => {
+      expect(() => proxy.validate()).not.toThrow();
+    });
+
+    it("toJSON", () => {
+      expect(proxy.toJSON()).toEqual({
+        apiVersion: "config.gateway.envoyproxy.io/v1alpha1",
+        kind: "EnvoyProxy",
+        metadata: {
+          namespace: "envoy-gateway-system",
+          name: "test"
+        },
+        spec: {
+          telemetry: {
+            accessLog: {
+              settings: [
+                {
+                  format: {
+                    type: "JSON",
+                    json: {
+                      protocol: "%PROTOCOL%",
+                      duration: "%DURATION%"
+                    }
+                  },
+                  sinks: [
+                    {
+                      type: "File",
+                      file: {
+                        path: "/dev/stdout"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      });
     });
   });
 });

--- a/third-party/envoy-gateway/scripts/download-crd.ts
+++ b/third-party/envoy-gateway/scripts/download-crd.ts
@@ -4,25 +4,29 @@ import { mkdir, writeFile } from "fs/promises";
 import yaml from "js-yaml";
 import { dirname, join } from "path";
 
-const VERSION = "0.6.0";
+const VERSIONS = ["0.5.0", "0.6.0"];
 
 const outputPath = join(__dirname, "../crds/crd.yaml");
 
 (async () => {
-  const content = await readInput(
-    `https://github.com/envoyproxy/gateway/releases/download/v${VERSION}/install.yaml`
-  );
-  const manifests: any[] = yaml.loadAll(content);
   const output: any[] = [];
 
-  for (const manifest of manifests) {
-    if (
-      manifest &&
-      manifest.apiVersion === "apiextensions.k8s.io/v1" &&
-      manifest.kind === "CustomResourceDefinition" &&
-      manifest.spec?.group === "gateway.envoyproxy.io"
-    ) {
-      output.push(manifest);
+  for (const version of VERSIONS) {
+    const content = await readInput(
+      `https://github.com/envoyproxy/gateway/releases/download/v${version}/install.yaml`
+    );
+    const manifests: any[] = yaml.loadAll(content);
+
+    for (const manifest of manifests) {
+      if (
+        manifest &&
+        manifest.apiVersion === "apiextensions.k8s.io/v1" &&
+        manifest.kind === "CustomResourceDefinition" &&
+        (manifest.spec?.group === "config.gateway.envoyproxy.io" ||
+          manifest.spec?.group === "gateway.envoyproxy.io")
+      ) {
+        output.push(manifest);
+      }
     }
   }
 


### PR DESCRIPTION
## Desc
Envoy Gateway **v0.6.0** has the breaking changes about CRD rename.
> Moved the EnvoyProxy CRD from config.gateway.envoyproxy.io to gateway.envoyproxy.io

## What was Done

This PR tried to install **v0.5.0** for better support

## Ref
https://gateway.envoyproxy.io/announcements/v0.6/#breaking-changes