### PR TITLE
Update ArgoCD CRD to v2.10.8

### DIFF
--- a/.changeset/fresh-kings-hide.md
+++ b/.changeset/fresh-kings-hide.md
@@ -1,0 +1,5 @@
+---
+"@kubernetes-models/argo-cd": minor
+---
+
+Upgrade to version `2.10.8`

--- a/third-party/argo-cd/package.json
+++ b/third-party/argo-cd/package.json
@@ -44,9 +44,9 @@
   },
   "crd-generate": {
     "input": [
-      "https://raw.githubusercontent.com/argoproj/argo-cd/v2.8.4/manifests/crds/application-crd.yaml",
-      "https://raw.githubusercontent.com/argoproj/argo-cd/v2.8.4/manifests/crds/applicationset-crd.yaml",
-      "https://raw.githubusercontent.com/argoproj/argo-cd/v2.8.4/manifests/crds/appproject-crd.yaml"
+      "https://raw.githubusercontent.com/argoproj/argo-cd/v2.10.8/manifests/crds/application-crd.yaml",
+      "https://raw.githubusercontent.com/argoproj/argo-cd/v2.10.8/manifests/crds/applicationset-crd.yaml",
+      "https://raw.githubusercontent.com/argoproj/argo-cd/v2.10.8/manifests/crds/appproject-crd.yaml"
     ],
     "output": "./gen"
   }


### PR DESCRIPTION
# Description

Update ArgoCD CRD to v2.10.8.

Ref: https://github.com/argoproj/argo-cd/releases/tag/v2.10.8
