### PR TITLE
Append index to generated paths to ensure correct import handling

### DIFF
--- a/.changeset/mean-years-add.md
+++ b/.changeset/mean-years-add.md
@@ -1,0 +1,6 @@
+---
+"@kubernetes-models/crd-generate": patch
+"@kubernetes-models/openapi-generate": patch
+---
+
+Append `/index` to generated paths to ensure correct import handling.

--- a/utils/crd-generate/src/generators/alias.ts
+++ b/utils/crd-generate/src/generators/alias.ts
@@ -18,7 +18,7 @@ function generate(map: KeyMap, parent = ""): OutputFile[] {
       content += `export * from "./${val}";\n`;
     } else {
       const exportedName = camelCase(key, ".-");
-      content += `export * as ${exportedName} from "./${key}";\n`;
+      content += `export * as ${exportedName} from "./${key}/index";\n`;
       children = children.concat(generate(val, parent + key + "/"));
     }
   }

--- a/utils/openapi-generate/src/generators/alias.ts
+++ b/utils/openapi-generate/src/generators/alias.ts
@@ -40,7 +40,7 @@ export default function ({ getDefinitionPath }: Context): Generator {
 
           output.push({
             path: aliasPath,
-            content: `export * from "${getRelativePath(aliasPath, defPath)}";`
+            content: `export * from "${getRelativePath(aliasPath, defPath)}/index";`
           });
         }
       }
@@ -74,7 +74,7 @@ export default function ({ getDefinitionPath }: Context): Generator {
           .map((v) => {
             const exportedName = camelCase(v, ".-");
 
-            return `export * as ${exportedName} from "./${v}";`;
+            return `export * as ${exportedName} from "./${v}/index";`;
           })
           .join("\n")
       });


### PR DESCRIPTION
Closes #214. Appends `index` to generated import paths to ensure directories are not treated as files when `rewriteImportPath` runs later.