### PR TITLE
Set model-defined props outside constructor to ensure useDefineForClassFields compatibility

### DIFF
--- a/.changeset/mighty-pets-press.md
+++ b/.changeset/mighty-pets-press.md
@@ -1,0 +1,56 @@
+---
+"@kubernetes-models/base": patch
+"@kubernetes-models/crd-generate": patch
+"@kubernetes-models/openapi-generate": patch
+"@kubernetes-models/apimachinery": patch
+"kubernetes-models": patch
+"@kubernetes-models/argo-cd": patch
+"@kubernetes-models/argo-rollouts": patch
+"@kubernetes-models/argo-workflows": patch
+"@kubernetes-models/autoscaler": patch
+"@kubernetes-models/cert-manager": patch
+"@kubernetes-models/cilium": patch
+"@kubernetes-models/cloudnative-pg": patch
+"@kubernetes-models/contour": patch
+"@kubernetes-models/elastic-cloud": patch
+"@kubernetes-models/envoy-gateway": patch
+"@kubernetes-models/external-secrets": patch
+"@kubernetes-models/fission": patch
+"@kubernetes-models/flagger": patch
+"@kubernetes-models/flux-cd": patch
+"@kubernetes-models/gateway-api": patch
+"@kubernetes-models/gke": patch
+"@kubernetes-models/grafana-agent-operator": patch
+"@kubernetes-models/grafana-operator": patch
+"@kubernetes-models/hierarchical-namespaces": patch
+"@kubernetes-models/istio": patch
+"@kubernetes-models/jaeger-operator": patch
+"@kubernetes-models/k8ssandra-operator": patch
+"@kubernetes-models/kapp-controller": patch
+"@kubernetes-models/karpenter": patch
+"@kubernetes-models/keda": patch
+"@kubernetes-models/knative": patch
+"@kubernetes-models/kubedb": patch
+"@kubernetes-models/kyverno": patch
+"@kubernetes-models/linkerd": patch
+"@kubernetes-models/longhorn": patch
+"@kubernetes-models/nats": patch
+"@kubernetes-models/pipelines-as-code": patch
+"@kubernetes-models/postgres-operator": patch
+"@kubernetes-models/prometheus-operator": patch
+"@kubernetes-models/rabbitmq-cluster-operator": patch
+"@kubernetes-models/rabbitmq-messaging-topology-operator": patch
+"@kubernetes-models/redis-operator": patch
+"@kubernetes-models/sealed-secrets": patch
+"@kubernetes-models/seldon-core-operator": patch
+"@kubernetes-models/shipwright": patch
+"@kubernetes-models/smi": patch
+"@kubernetes-models/spicedb": patch
+"@kubernetes-models/spiffe": patch
+"@kubernetes-models/thanos-operator": patch
+"@kubernetes-models/tidb-operator": patch
+"@kubernetes-models/traefik": patch
+"@kubernetes-models/victoria-metrics-operator": patch
+---
+
+Set model-defined props outside constructor to ensure `useDefineForClassFields` compatibility.

--- a/core/base/src/model.ts
+++ b/core/base/src/model.ts
@@ -36,6 +36,12 @@ export class Model<T> {
     }
   }
 
+  protected setDefinedProps(data?: ModelData<T>): any {
+    if (data) {
+      setDefinedProps(data, this);
+    }
+  }
+
   public toJSON(): any {
     const result = {};
 

--- a/first-party/kubernetes-models/__tests__/class.ts
+++ b/first-party/kubernetes-models/__tests__/class.ts
@@ -29,10 +29,6 @@ describe("Deployment apps/v1", () => {
     expect(deployment.metadata).toEqual({ name: "test" });
   });
 
-  it("should not set sepc", () => {
-    expect(deployment).not.toHaveProperty("spec");
-  });
-
   it("toJSON", () => {
     expect(deployment.toJSON()).toEqual({
       apiVersion: "apps/v1",
@@ -65,10 +61,6 @@ describe("Deployment apps/v1beta1", () => {
 
   it("should set metadata", () => {
     expect(deployment.metadata).toEqual({ name: "test" });
-  });
-
-  it("should not set sepc", () => {
-    expect(deployment).not.toHaveProperty("spec");
   });
 
   it("toJSON", () => {

--- a/third-party/gke/__tests__/class.ts
+++ b/third-party/gke/__tests__/class.ts
@@ -25,10 +25,6 @@ describe("BackendConfig", () => {
     expect(config.metadata).toEqual({ name: "test" });
   });
 
-  it("should not set sepc", () => {
-    expect(config).not.toHaveProperty("spec");
-  });
-
   it("toJSON", () => {
     expect(config.toJSON()).toEqual({
       apiVersion: "cloud.google.com/v1beta1",

--- a/utils/crd-generate/src/generators/definition.ts
+++ b/utils/crd-generate/src/generators/definition.ts
@@ -49,7 +49,9 @@ static kind: ${interfaceName}["kind"] = ${JSON.stringify(gvk.kind)};
 static is = createTypeMetaGuard<${interfaceName}>(${className});
 
 constructor(data?: ModelData<${interfaceName}>) {
-  super({
+  super();
+
+  this.setDefinedProps({
     apiVersion: ${className}.apiVersion,
     kind: ${className}.kind,
     ...data

--- a/utils/openapi-generate/src/generators/definition.ts
+++ b/utils/openapi-generate/src/generators/definition.ts
@@ -117,12 +117,12 @@ export default function ({
           }
         });
 
-        if (gvk) {
-          imports.push({
-            name: "ModelData",
-            path: "@kubernetes-models/base"
-          });
+        imports.push({
+          name: "ModelData",
+          path: "@kubernetes-models/base"
+        });
 
+        if (gvk) {
           imports.push({
             name: "TypeMeta",
             path: "@kubernetes-models/base"
@@ -141,11 +141,21 @@ static kind: ${shortInterfaceName}["kind"] = "${gvk.kind}";
 static is = createTypeMetaGuard<${shortInterfaceName}>(${shortClassName});
 
 constructor(data?: ModelData<${shortInterfaceName}>) {
-  super({
+  super();
+
+  this.setDefinedProps({
     apiVersion: ${shortClassName}.apiVersion,
     kind: ${shortClassName}.kind,
     ...data
   } as ${shortInterfaceName});
+}
+}`;
+        } else {
+          classContent = `${trimSuffix(classContent, "}")}
+constructor(data?: ModelData<${shortInterfaceName}>) {
+  super();
+
+  this.setDefinedProps(data);
 }
 }`;
         }


### PR DESCRIPTION
This pull request amends the model generator to call `setDefinedProps` outside the `Model` constructor, to ensure compatibility with runtimes that force the `useDefineForClassFields` option to true, like Deno (see https://github.com/denoland/deno/issues/12393). Without this option, all fields are overwritten to `undefined` after the constructor call.

I have tested this change with `useDefineForClassFields` set to both true and false. I have removed three test cases that assert the non-existence of the `spec` field, as it is not possible to ensure consistency of its existence with different states of `useDefineForClassFields` (it will be present but undefined when true, and not present when false).
