### PR TITLE
feat(external-secrets): bump external-secrets from 0.8.1 to 0.16.1

### DIFF
--- a/.changeset/afraid-hounds-help.md
+++ b/.changeset/afraid-hounds-help.md
@@ -1,0 +1,5 @@
+---
+"@kubernetes-models/external-secrets": minor
+---
+
+bump external-secrets from 0.8.1 to 0.16.1

--- a/third-party/external-secrets/package.json
+++ b/third-party/external-secrets/package.json
@@ -43,7 +43,7 @@
   },
   "crd-generate": {
     "input": [
-      "https://github.com/external-secrets/external-secrets/releases/download/v0.8.1/external-secrets.yaml"
+      "https://github.com/external-secrets/external-secrets/releases/download/v0.16.1/external-secrets.yaml"
     ],
     "output": "./gen"
   }

--- a/third-party/external-secrets/package.json
+++ b/third-party/external-secrets/package.json
@@ -43,7 +43,7 @@
   },
   "crd-generate": {
     "input": [
-      "https://github.com/external-secrets/external-secrets/releases/download/v0.16.1/external-secrets.yaml"
+      "https://github.com/external-secrets/external-secrets/releases/download/v0.16.2/external-secrets.yaml"
     ],
     "output": "./gen"
   }


### PR DESCRIPTION
[0.8.1 ](https://github.com/external-secrets/external-secrets/releases/tag/v0.8.1) was released on Mar 18, 2023 which is way out-of-date.

By using the latest [0.16.2](https://github.com/external-secrets/external-secrets/releases/tag/v0.16.2) version, it enables new features such as 
- the new v1 version
- the new refreshPolicy option
- and more...