### PR TITLE
feat(tidb-operator): upgrade CRDs from v1.4.4 to v1.6.3

### DIFF
--- a/.changeset/tidb-operator-upgrade.md
+++ b/.changeset/tidb-operator-upgrade.md
@@ -1,0 +1,5 @@
+---
+"@kubernetes-models/tidb-operator": minor
+---
+
+Update TiDB operator CRDs from v1.4.4 to v1.6.3

--- a/third-party/tidb-operator/package.json
+++ b/third-party/tidb-operator/package.json
@@ -43,7 +43,7 @@
   },
   "crd-generate": {
     "input": [
-      "https://raw.githubusercontent.com/pingcap/tidb-operator/v1.4.4/manifests/crd.yaml"
+      "https://raw.githubusercontent.com/pingcap/tidb-operator/v1.6.3/manifests/crd.yaml"
     ],
     "output": "./gen"
   }


### PR DESCRIPTION
## Summary
- Upgraded TiDB operator CRDs from v1.4.4 to v1.6.3
- Regenerated TypeScript models with the latest CRD definitions
- All tests pass successfully