### PR TITLE
feat(keda): upgrade CRDs from v2.10.1 to v2.19.0

### DIFF
--- a/.changeset/keda-upgrade.md
+++ b/.changeset/keda-upgrade.md
@@ -1,0 +1,5 @@
+---
+"@kubernetes-models/keda": minor
+---
+
+Update KEDA CRDs from v2.10.1 to v2.19.0

--- a/third-party/keda/package.json
+++ b/third-party/keda/package.json
@@ -43,7 +43,7 @@
   },
   "crd-generate": {
     "input": [
-      "https://github.com/kedacore/keda/releases/download/v2.10.1/keda-2.10.1.yaml"
+      "https://github.com/kedacore/keda/releases/download/v2.19.0/keda-2.19.0.yaml"
     ],
     "output": "./gen"
   }


### PR DESCRIPTION
## What

Upgrade `@kubernetes-models/keda` CRDs from KEDA v2.10.1 to v2.19.0.

## Why

KEDA v2.10.1 was released in 2023; v2.19.0 is the latest upstream release (2026-02). The package was 9 minor versions behind upstream.

## How

- Bump the CRD source URL in `third-party/keda/package.json` `crd-generate.input` to point at the v2.19.0 install manifest, mirroring the prior pattern.
- Add a changeset (`minor`) — matches the convention used for the recent `tidb-operator` upgrade (#248).

The new manifest adds two CRDs in the `eventing.keda.sh/v1alpha1` group: `CloudEventSource` and `ClusterCloudEventSource`. Existing CRDs (`ScaledJob`, `ScaledObject`, `TriggerAuthentication`, `ClusterTriggerAuthentication`) continue to generate and the existing tests pass locally.