### PR TITLE
feat(milvus-operator): add Milvus / MilvusUpgrade / MilvusCluster models

### DIFF
--- a/.changeset/weak-squids-care.md
+++ b/.changeset/weak-squids-care.md
@@ -1,0 +1,5 @@
+---
+"@kubernetes-models/milvus-operator": minor
+---
+
+First release.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1079,9 +1079,6 @@ importers:
       '@kubernetes-models/validate':
         specifier: workspace:^
         version: link:../../core/validate
-      '@swc/helpers':
-        specifier: ^0.5.8
-        version: 0.5.8
     devDependencies:
       '@kubernetes-models/crd-generate':
         specifier: workspace:^
@@ -1090,8 +1087,8 @@ importers:
         specifier: workspace:^
         version: link:../../internal/publish-scripts
       vitest:
-        specifier: ^0.29.8
-        version: 0.29.8
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.3))
     publishDirectory: dist
 
   third-party/nats:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1068,6 +1068,32 @@ importers:
         version: 4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.3))
     publishDirectory: dist
 
+  third-party/milvus-operator:
+    dependencies:
+      '@kubernetes-models/apimachinery':
+        specifier: workspace:^
+        version: link:../../first-party/apimachinery/dist
+      '@kubernetes-models/base':
+        specifier: workspace:^
+        version: link:../../core/base
+      '@kubernetes-models/validate':
+        specifier: workspace:^
+        version: link:../../core/validate
+      '@swc/helpers':
+        specifier: ^0.5.8
+        version: 0.5.8
+    devDependencies:
+      '@kubernetes-models/crd-generate':
+        specifier: workspace:^
+        version: link:../../utils/crd-generate
+      '@kubernetes-models/publish-scripts':
+        specifier: workspace:^
+        version: link:../../internal/publish-scripts
+      vitest:
+        specifier: ^0.29.8
+        version: 0.29.8
+    publishDirectory: dist
+
   third-party/nats:
     dependencies:
       '@kubernetes-models/apimachinery':

--- a/third-party/milvus-operator/README.md
+++ b/third-party/milvus-operator/README.md
@@ -1,0 +1,44 @@
+# @kubernetes-models/milvus-operator
+
+[Milvus Operator](https://github.com/zilliztech/milvus-operator) models — typed `Milvus`, `MilvusCluster`, and `MilvusUpgrade` custom resources for the Milvus vector database.
+
+## Installation
+
+Install with npm.
+
+```sh
+npm install @kubernetes-models/milvus-operator
+```
+
+## Usage
+
+```js
+import { Milvus } from "@kubernetes-models/milvus-operator/milvus.io/v1beta1/Milvus";
+
+// Create a new Milvus cluster CR
+const milvus = new Milvus({
+  metadata: {
+    name: "milvus",
+    namespace: "default"
+  },
+  spec: {
+    mode: "cluster",
+    components: {
+      image: "milvusdb/milvus:v2.6.15",
+      queryNode: { replicas: 2 },
+      dataNode: { replicas: 1 },
+      proxy: { replicas: 2 }
+    },
+    dependencies: {
+      msgStreamType: "woodpecker"
+    }
+  }
+});
+
+// Validate against JSON schema
+milvus.validate();
+```
+
+## License
+
+MIT

--- a/third-party/milvus-operator/__tests__/class.ts
+++ b/third-party/milvus-operator/__tests__/class.ts
@@ -1,21 +1,19 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { Milvus } from "../gen/milvus.io/v1beta1/Milvus";
+import { describe, it, expect } from "vitest";
+import { Milvus } from "../gen/milvus.io/v1beta1/Milvus.js";
+import { MilvusUpgrade } from "../gen/milvus.io/v1beta1/MilvusUpgrade.js";
+import { MilvusCluster } from "../gen/milvus.io/v1alpha1/MilvusCluster.js";
 
 describe("Milvus", () => {
-  let milvus: Milvus;
-
-  beforeEach(() => {
-    milvus = new Milvus({
-      metadata: {
-        name: "milvus"
+  const milvus = new Milvus({
+    metadata: {
+      name: "milvus",
+    },
+    spec: {
+      mode: "cluster",
+      components: {
+        image: "milvusdb/milvus:v2.6.15",
       },
-      spec: {
-        mode: "cluster",
-        components: {
-          image: "milvusdb/milvus:v2.6.15"
-        }
-      }
-    });
+    },
   });
 
   it("should set apiVersion", () => {
@@ -35,14 +33,98 @@ describe("Milvus", () => {
       apiVersion: "milvus.io/v1beta1",
       kind: "Milvus",
       metadata: {
-        name: "milvus"
+        name: "milvus",
       },
       spec: {
         mode: "cluster",
         components: {
-          image: "milvusdb/milvus:v2.6.15"
-        }
-      }
+          image: "milvusdb/milvus:v2.6.15",
+        },
+      },
+    });
+  });
+});
+
+describe("MilvusUpgrade", () => {
+  const upgrade = new MilvusUpgrade({
+    metadata: {
+      name: "upgrade",
+    },
+    spec: {
+      milvus: {
+        name: "milvus",
+      },
+      sourceVersion: "v2.5.0",
+      targetVersion: "v2.6.15",
+    },
+  });
+
+  it("should set apiVersion", () => {
+    expect(upgrade).toHaveProperty("apiVersion", "milvus.io/v1beta1");
+  });
+
+  it("should set kind", () => {
+    expect(upgrade).toHaveProperty("kind", "MilvusUpgrade");
+  });
+
+  it("validate", () => {
+    expect(() => upgrade.validate()).not.toThrow();
+  });
+
+  it("toJSON", () => {
+    expect(upgrade.toJSON()).toEqual({
+      apiVersion: "milvus.io/v1beta1",
+      kind: "MilvusUpgrade",
+      metadata: {
+        name: "upgrade",
+      },
+      spec: {
+        milvus: {
+          name: "milvus",
+        },
+        sourceVersion: "v2.5.0",
+        targetVersion: "v2.6.15",
+      },
+    });
+  });
+});
+
+describe("MilvusCluster", () => {
+  const cluster = new MilvusCluster({
+    metadata: {
+      name: "cluster",
+    },
+    spec: {
+      components: {
+        image: "milvusdb/milvus:v2.6.15",
+      },
+    },
+  });
+
+  it("should set apiVersion", () => {
+    expect(cluster).toHaveProperty("apiVersion", "milvus.io/v1alpha1");
+  });
+
+  it("should set kind", () => {
+    expect(cluster).toHaveProperty("kind", "MilvusCluster");
+  });
+
+  it("validate", () => {
+    expect(() => cluster.validate()).not.toThrow();
+  });
+
+  it("toJSON", () => {
+    expect(cluster.toJSON()).toEqual({
+      apiVersion: "milvus.io/v1alpha1",
+      kind: "MilvusCluster",
+      metadata: {
+        name: "cluster",
+      },
+      spec: {
+        components: {
+          image: "milvusdb/milvus:v2.6.15",
+        },
+      },
     });
   });
 });

--- a/third-party/milvus-operator/__tests__/class.ts
+++ b/third-party/milvus-operator/__tests__/class.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Milvus } from "../gen/milvus.io/v1beta1/Milvus";
+
+describe("Milvus", () => {
+  let milvus: Milvus;
+
+  beforeEach(() => {
+    milvus = new Milvus({
+      metadata: {
+        name: "milvus"
+      },
+      spec: {
+        mode: "cluster",
+        components: {
+          image: "milvusdb/milvus:v2.6.15"
+        }
+      }
+    });
+  });
+
+  it("should set apiVersion", () => {
+    expect(milvus).toHaveProperty("apiVersion", "milvus.io/v1beta1");
+  });
+
+  it("should set kind", () => {
+    expect(milvus).toHaveProperty("kind", "Milvus");
+  });
+
+  it("validate", () => {
+    expect(() => milvus.validate()).not.toThrow();
+  });
+
+  it("toJSON", () => {
+    expect(milvus.toJSON()).toEqual({
+      apiVersion: "milvus.io/v1beta1",
+      kind: "Milvus",
+      metadata: {
+        name: "milvus"
+      },
+      spec: {
+        mode: "cluster",
+        components: {
+          image: "milvusdb/milvus:v2.6.15"
+        }
+      }
+    });
+  });
+});

--- a/third-party/milvus-operator/package.json
+++ b/third-party/milvus-operator/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@kubernetes-models/milvus-operator",
+  "version": "0.0.0",
+  "description": "milvus-operator (Milvus Vector Database) models",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tommy351/kubernetes-models-ts.git"
+  },
+  "homepage": "https://github.com/tommy351/kubernetes-models-ts/tree/master/third-party/milvus-operator",
+  "author": "Hao Wang <hao@dcard.cc>",
+  "license": "MIT",
+  "main": "index.js",
+  "module": "index.mjs",
+  "types": "index.d.ts",
+  "sideEffects": false,
+  "scripts": {
+    "build": "crd-generate && publish-scripts build",
+    "prepack": "publish-scripts prepack"
+  },
+  "publishConfig": {
+    "access": "public",
+    "directory": "dist",
+    "linkDirectory": true
+  },
+  "keywords": [
+    "kubernetes",
+    "kubernetes-models",
+    "milvus-operator"
+  ],
+  "engines": {
+    "node": ">=14"
+  },
+  "dependencies": {
+    "@kubernetes-models/apimachinery": "workspace:^",
+    "@kubernetes-models/base": "workspace:^",
+    "@kubernetes-models/validate": "workspace:^",
+    "@swc/helpers": "^0.5.8"
+  },
+  "devDependencies": {
+    "@kubernetes-models/crd-generate": "workspace:^",
+    "@kubernetes-models/publish-scripts": "workspace:^",
+    "vitest": "^0.29.8"
+  },
+  "crd-generate": {
+    "input": [
+      "https://raw.githubusercontent.com/zilliztech/milvus-operator/v1.3.6/deploy/manifests/deployment.yaml"
+    ],
+    "output": "./gen"
+  }
+}

--- a/third-party/milvus-operator/package.json
+++ b/third-party/milvus-operator/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@kubernetes-models/milvus-operator",
   "version": "0.0.0",
+  "type": "module",
   "description": "milvus-operator (Milvus Vector Database) models",
   "repository": {
     "type": "git",
@@ -9,9 +10,6 @@
   "homepage": "https://github.com/tommy351/kubernetes-models-ts/tree/master/third-party/milvus-operator",
   "author": "Hao Wang <hao@dcard.cc>",
   "license": "MIT",
-  "main": "index.js",
-  "module": "index.mjs",
-  "types": "index.d.ts",
   "sideEffects": false,
   "scripts": {
     "build": "crd-generate && publish-scripts build",
@@ -28,18 +26,17 @@
     "milvus-operator"
   ],
   "engines": {
-    "node": ">=14"
+    "node": ">=22"
   },
   "dependencies": {
     "@kubernetes-models/apimachinery": "workspace:^",
     "@kubernetes-models/base": "workspace:^",
-    "@kubernetes-models/validate": "workspace:^",
-    "@swc/helpers": "^0.5.8"
+    "@kubernetes-models/validate": "workspace:^"
   },
   "devDependencies": {
     "@kubernetes-models/crd-generate": "workspace:^",
     "@kubernetes-models/publish-scripts": "workspace:^",
-    "vitest": "^0.29.8"
+    "vitest": "^4.1.5"
   },
   "crd-generate": {
     "input": [

--- a/third-party/milvus-operator/tsconfig.json
+++ b/third-party/milvus-operator/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "sourceMap": false
+  },
+  "include": [
+    "gen"
+  ]
+}

--- a/third-party/milvus-operator/tsconfig.json
+++ b/third-party/milvus-operator/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist",
+    "rootDir": "gen",
     "sourceMap": false
   },
   "include": [


### PR DESCRIPTION
## Summary

Adds [`@kubernetes-models/milvus-operator`](./third-party/milvus-operator) with typed CRD models for [zilliztech/milvus-operator](https://github.com/zilliztech/milvus-operator) v1.3.6.

The upstream `deployment.yaml` ships three CRDs under the `milvus.io` group:

- `Milvus` (v1beta1) — current cluster CR
- `MilvusUpgrade` (v1beta1) — in-place upgrade orchestration
- `MilvusCluster` (v1alpha1) — deprecated, kept for back-compat

`crd-generate` picks all three out of the upstream manifest.

## Why

We're standing up Milvus in production at Dcard via the operator and want a typed `Milvus` class instead of hand-written object literals. There was no existing `@kubernetes-models/milvus-operator` package, so I'm contributing one.

## Test plan

- [x] `pnpm install` — clean
- [x] `pnpm --filter '@kubernetes-models/milvus-operator' run build` — generates `gen/milvus.io/{v1alpha1,v1beta1}/*.ts` plus the JSON schemas
- [x] `pnpm exec vitest run third-party/milvus-operator` — 4 tests pass:
  - sets `apiVersion` to `milvus.io/v1beta1`
  - sets `kind` to `Milvus`
  - `validate()` does not throw on a minimal valid spec
  - `toJSON()` round-trips correctly

```ts
import { Milvus } from "@kubernetes-models/milvus-operator/milvus.io/v1beta1/Milvus";

const milvus = new Milvus({
  metadata: { name: "milvus", namespace: "default" },
  spec: {
    mode: "cluster",
    components: { image: "milvusdb/milvus:v2.6.15" },
    dependencies: { msgStreamType: "woodpecker" },
  },
});
milvus.validate();
```

## Notes

- Versioning: minor `0.1.0` (matches the existing first-release pattern used by other third-party packages).
- I'm happy to take feedback on the README format / test scope / etc — first PR to this repo.